### PR TITLE
Fix for views count in other languages + more original look

### DIFF
--- a/chrome/main.js
+++ b/chrome/main.js
@@ -4078,7 +4078,7 @@ function watchPageEveryLoad() {
 		// View Count
 		var cutString = trueCounts.split(' • ');
 		var trueViewCount = cutString[0];
-		var cutString2 = trueViewCount.split(' v');
+		var cutString2 = trueViewCount.replace(/(.+\d) \D+|\D+ (.+\d)/, "$1$2").replace(" ", ",");
 		var trueViewCountTrimmed = cutString2[0];
 		//TEMP FIX
 		if (

--- a/chrome/main.js
+++ b/chrome/main.js
@@ -4078,8 +4078,7 @@ function watchPageEveryLoad() {
 		// View Count
 		var cutString = trueCounts.split(' • ');
 		var trueViewCount = cutString[0];
-		var cutString2 = trueViewCount.replace(/(.+\d) \D+|\D+ (.+\d)/, "$1$2").replace(" ", ",");
-		var trueViewCountTrimmed = cutString2[0];
+		var trueViewCountTrimmed = trueViewCount.replace(/(.+\d) \D+|\D+ (.+\d)/, "$1$2").replace(" ", ",");
 		//TEMP FIX
 		if (
 		BTConfig.layoutSelect != "none" &&


### PR DESCRIPTION
Currently the view count is broken in other languages, as not all languages have the "views" word start with "v", and iirc languages like Arabic may have the text FIRST, and then the number. That's why the view count also contains the "views" word in languages other than English. This should fix both cases. I've also made it replace spaces between views counter with an `,` character, which __was__ present in older layouts (at least Cosmic Panda and 2008 layout), as seen on screenshots online.