### PR TITLE
XSS prevention hardening (Return YouTube Dislike)

### DIFF
--- a/chrome beta/scripts/emerald.js
+++ b/chrome beta/scripts/emerald.js
@@ -5776,8 +5776,8 @@ function doRyd(videoId) {
 		"method": "GET"
 	}).then(response => response.json()).then(data => {
 		console.log(data);
-		var likeCount = data.likes;
-		var dislikeCount = data.dislikes;
+		var likeCount = parseInt(data.likes);
+		var dislikeCount = parseInt(data.dislikes);
 		var total = likeCount + dislikeCount;
 		console.log(total);
 		var rating = dislikeCount / total;

--- a/firefox beta/scripts/emerald.js
+++ b/firefox beta/scripts/emerald.js
@@ -5776,8 +5776,8 @@ function doRyd(videoId) {
 		"method": "GET"
 	}).then(response => response.json()).then(data => {
 		console.log(data);
-		var likeCount = data.likes;
-		var dislikeCount = data.dislikes;
+		var likeCount = parseInt(data.likes);
+		var dislikeCount = parseInt(data.dislikes);
 		var total = likeCount + dislikeCount;
 		console.log(total);
 		var rating = dislikeCount / total;


### PR DESCRIPTION
As in title. The code already seems to have enough amount of XSS prevention, but this PR prevents *any* non-number data to be displayed on the webpage. It's not a big deal on first glance, but RYD is 3rd party so it should be primary to treat it as "unsafe" (I mean yes, it's popular, but that's a good security measure to treat it as "unsafe" anyways), to even prevent unwanted text on the webpage in case of RYD getting hacked. Any non-number data will be displayed as `NaN`, as expected (since this should never happen if RYD works properly, otherwise there's something wrong that should be fixed).

As of now, anything that isn't a number can be displayed anyways, it's not a big deal since `textContent` seems to prevent XSS, but it would be scary for users to see a message like "You're hacked by XYZ".